### PR TITLE
use port.alias if set

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ links:
   - src: "Novation SL MkIII 1:(capture_2) Novation SL MkIII MIDI 3"
     dst: "Virtual Raw MIDI 4-3 4:(playback_0) VirMIDI 4-3"
   - src: "Novation SL MkIII 1:(capture_0) Novation SL MkIII MIDI 1"
-    dst: "keyboard"
+    dst: "ALC257 Analog:playback_FR"
 ```
 
 Recall that you can pretty much embed JSON inside YAML, so you should
@@ -57,7 +57,7 @@ You can see the names using the excellent
 [`jq`](https://stedolan.github.io/jq/) tool with e.g.
 
 ```
-% pw-dump | jq '.[].info.props."port.name"|select(.)'
+% pw-dump | jq '.[].info.props."port.alias"|select(.)'
 "Midi Through:(capture_0) Midi Through Port-0"
 "Midi Through:(playback_0) Midi Through Port-0"
 "Novation SL MkIII 1:(capture_0) Novation SL MkIII MIDI 1"
@@ -76,11 +76,10 @@ You can see the names using the excellent
 "Virtual Raw MIDI 4-2 4:(playback_0) VirMIDI 4-2"
 "Virtual Raw MIDI 4-3 4:(capture_0) VirMIDI 4-3"
 "Virtual Raw MIDI 4-3 4:(playback_0) VirMIDI 4-3"
-"keyboard"
-"monitor_FL"
-"monitor_FR"
-"playback_FL"
-"playback_FR"
+"ALC257 Analog:monitor_FL"
+"ALC257 Analog:monitor_FR"
+"ALC257 Analog:playback_FL"
+"ALC257 Analog:playback_FR"
 ```
 
 Once running, `pw-connections` should be fire and forget. Connections

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,7 +220,10 @@ impl Main {
                     props.get("port.id"),
                     props.get("port.direction"),
                 ) {
-                    let port_name = PortName(port_name.clone());
+                    let mut port_name = PortName(port_name.clone());
+                    if let Some(port_alias) = props.get("port.alias") {
+                        port_name = PortName(port_alias.clone())
+                    }
                     let port_id = PortId(port_id.clone());
                     let node_id = NodeId(node_id.clone());
                     let port_direction = PortDirection::from(port_direction);


### PR DESCRIPTION
Only looking at `port.name`, I get plenty of duplicated port names.

```
"Midi Through:(playback_0) Midi Through Port-0"
"Midi Through:(capture_0) Midi Through Port-0"
"out_0"
"playback_FL"
"monitor_FL"
"playback_FR"
"monitor_FR"
"capture_FL"
"capture_FR"
"out_0"
"Scarlett 2i4 USB 2:(playback_0) Scarlett 2i4 USB MIDI 1"
"Scarlett 2i4 USB 2:(capture_0) Scarlett 2i4 USB MIDI 1"
"playback_FL"
"monitor_FL"
"playback_FR"
"monitor_FR"
"playback_FL"
"monitor_FL"
"playback_FR"
"monitor_FR"
"playback_RL"
"monitor_RL"
"playback_RR"
"monitor_RR"
"capture_FL"
"capture_FR"
"capture_MONO"
"output_FL"
"output_FR"
"output_RL"
"output_RR"
"output_FL"
"output_FR"
"output_RL"
"output_RR"
...
```

With this PR it uses `port.alias`, if set, which allows unambiguous matching (there are a few duplicates of names, but together with the port direction they are still unique)


```
"Midi Through:Midi Through Port-0"
"Midi Through:Midi Through Port-0"
"Integrated Camera  Integrated C:out_0"
"ALC257 Analog:playback_FL"
"ALC257 Analog:monitor_FL"
"ALC257 Analog:playback_FR"
"ALC257 Analog:monitor_FR"
"ALC257 Analog:capture_FL"
"ALC257 Analog:capture_FR"
"Integrated Camera:out_0"
"Scarlett 2i4 USB:Scarlett 2i4 USB MIDI 1"
"Scarlett 2i4 USB:Scarlett 2i4 USB MIDI 1"
"ThinkPad USB-C Dock Gen2 USB Au:playback_FL"
"ThinkPad USB-C Dock Gen2 USB Au:monitor_FL"
"ThinkPad USB-C Dock Gen2 USB Au:playback_FR"
"ThinkPad USB-C Dock Gen2 USB Au:monitor_FR"
"Scarlett 2i4 USB:playback_FL"
"Scarlett 2i4 USB:monitor_FL"
"Scarlett 2i4 USB:playback_FR"
"Scarlett 2i4 USB:monitor_FR"
"Scarlett 2i4 USB:playback_RL"
"Scarlett 2i4 USB:monitor_RL"
"Scarlett 2i4 USB:playback_RR"
"Scarlett 2i4 USB:monitor_RR"
"Scarlett 2i4 USB:capture_FL"
"Scarlett 2i4 USB:capture_FR"
"ThinkPad USB-C Dock Gen2 USB Au:capture_MONO"
"speech-dispatcher-dummy:output_FL"
"speech-dispatcher-dummy:output_FR"
"speech-dispatcher-dummy:output_RL"
"speech-dispatcher-dummy:output_RR"
"Chromium:output_FL"
"Chromium:output_FR"
"Chromium:output_RL"
"Chromium:output_RR"
...
```